### PR TITLE
Remove .env from git tracking

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-<<<<<<< HEAD
-MONGODB_URI="mongodb://localhost:27017/jaguar-hack"
-PORT="5000"
-=======
-JWT_SECRET_KEY="jaguar"
->>>>>>> 1c6cfa7b62b1f3a870cadf10e752a5617a4d4aed

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.env


### PR DESCRIPTION
Remove `.env` from git tracking due to reasons mentioned [here](https://platform.sh/blog/2021/we-need-to-talk-about-the-env/) among others.

> ".env files are a surrogate environment variable for local development only, but should never be committed to Git."


[This one as well](https://dev.to/somedood/please-dont-commit-env-3o9h) 
> "Sure, committing the .env file is a grave mistake."
