### PR TITLE
fix bug create new participant per GET

### DIFF
--- a/controllers/petitions.controller.js
+++ b/controllers/petitions.controller.js
@@ -240,7 +240,7 @@ petitionsController.read = catchAsync(async (req, res) => {
         },
         { new: true }
       ).populate("owner");
-      newPetition.save();
+      // newPetition.save();
 
       return await newPetition;
     })


### PR DESCRIPTION
The GET request for petitions generates new participants because we have a .pre() hook to do so after every Petition save. This hook is meant for POST request.  